### PR TITLE
Add array-based schedule configuration support for queues

### DIFF
--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -224,7 +224,7 @@ describe("Validation", () => {
   });
 
   describe("Schedule key deduplication", () => {
-    it("should allow multiple schedules with different keys", () => {
+    it("should allow multiple schedules with different keys, specified individually", () => {
       const queue = createQueue()
         .input<{ test: string }>()
         .schedule({
@@ -247,7 +247,7 @@ describe("Validation", () => {
       expect(queue.schedules?.[1]?.key).toBe("schedule2");
     });
 
-    it("should override schedule with same key", () => {
+    it("should override schedule with same key, specified individually", () => {
       const queue = createQueue()
         .input<{ test: string }>()
         .schedule({
@@ -260,6 +260,56 @@ describe("Validation", () => {
           data: { test: "value2" },
           key: "daily",
         })
+        .handler(() => {
+          // Test handler
+          return {};
+        });
+
+      expect(queue.schedules).toHaveLength(1);
+      expect(queue.schedules?.[0]?.key).toBe("daily");
+      expect(queue.schedules?.[0]?.cron).toBe("0 12 * * *");
+      expect(queue.schedules?.[0]?.data).toEqual({ test: "value2" });
+    });
+    it("should allow multiple schedules with different keys, specified as an array", () => {
+      const queue = createQueue()
+        .input<{ test: string }>()
+        .schedules([
+          {
+            cron: "0 0 * * *",
+            data: { test: "value1" },
+            key: "schedule1",
+          },
+          {
+            cron: "0 */6 * * *",
+            data: { test: "value2" },
+            key: "schedule2",
+          },
+        ])
+        .handler(() => {
+          // Test handler
+          return {};
+        });
+
+      expect(queue.schedules).toHaveLength(2);
+      expect(queue.schedules?.[0]?.key).toBe("schedule1");
+      expect(queue.schedules?.[1]?.key).toBe("schedule2");
+    });
+
+    it("should override schedule with same key, specified individually", () => {
+      const queue = createQueue()
+        .input<{ test: string }>()
+        .schedules([
+          {
+            cron: "0 0 * * *",
+            data: { test: "value1" },
+            key: "daily",
+          },
+          {
+            cron: "0 12 * * *",
+            data: { test: "value2" },
+            key: "daily",
+          },
+        ])
         .handler(() => {
           // Test handler
           return {};

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type {
   QueueHandler,
   QueueOptions,
   QueueRegistry,
+  QueueSchedule,
   QueuesMap,
   QueueWithoutName,
   SingleQueueDefinition,

--- a/src/queues/builder.ts
+++ b/src/queues/builder.ts
@@ -124,6 +124,36 @@ export class QueueBuilder<TInput = unknown, TOutput = void> {
     return this;
   }
 
+  /**
+   * Define multiple schedules for this job.
+   *
+   * @param configs - Array of schedule configurations with cron expression, data, and key
+   * @throws TypeError if key is empty or cron expression is invalid
+   *
+   * @example
+   * ```typescript
+   * const job = createQueue()
+   *   .input<{ type: string }>()
+   *   .schedules([{
+   *     key: 'daily',
+   *     cron: '0 0 * * *',  // Every day at midnight
+   *     data: { type: 'daily-report' }
+   *   },{
+   *     key: 'hourly',
+   *     cron: '0 * * * *',  // Every hour
+   *     data: { type: 'hourly-sync' }
+   *   })
+   *   .handler(async (input) => { ... });
+   * ```
+   */
+  schedules(configs: QueueSchedule<TInput>[]): QueueBuilder<TInput, TOutput> {
+    for (const config of configs) {
+      this.schedule(config);
+    }
+
+    return this;
+  }
+
   private upsertSchedule(schedule: QueueSchedule<TInput>) {
     this.queueSchedules = this.queueSchedules.filter(
       (existing) => existing.key !== schedule.key


### PR DESCRIPTION
Hi, thanks for this really useful addition to the pg-boss ecosystem. 

We like to keep everything about our jobs specified with the job in the same module. A contrived example: 

```typescript
// jobs/heartbeat-cron.ts
import type { QueueSchedule } from "pg-bossman";

import { z } from "zod";

export const name = "heartbeat-cron";

export const schedules: QueueSchedule[] = [
  {
    key: "17-past-hour",
    cron: "17 * * * *",
  },
  {
    key: "midnight",
    cron: "0 0 * * *",
  },
];

const schema = z.object({}).prefault({});
export type Input = z.infer<typeof schema>;

export function handler(data: Input, logger: Logger) {
  schema.parse(data);
  console.debug(`Heartbeat Cron: ${new Date.toISOString()}`);
}

```

which, with this change, we can then do this: 
```typescript
import { createBossman, createQueue } from "pg-bossman";
import * as heartbeatCron from "jobs/heartbeat-cron";

const queues = { 
  [heartbeatCron.name]: createQueue()
    .schedules(heartbeatCron.schedules)
    .input<heartbeatCron.Input>()
    .handler(heartbeatCron.handler),
};

export const bossman = bossmanClient.register(queues).build().start();
```

at the moment we're using a helper function to wrap the `QueueBuilder`:
```typescript
type QueueSchedule = Parameters<QueueBuilder["schedule"]>[0];

function applySchedules(queue: QueueBuilder, schedules: QueueSchedule[]) {
  for (const schedule of schedules) {
    queue.schedule(schedule);
  }
  return queue;
}

const queues = {
  [heartbeatCron.name]: applySchedules(createQueue(), heartbeatCron.schedules)
    .input<heartbeatCron.Input>()
    .handler(heartbeatCron.handler),
};
```


Hopefully this is a useful addition. If not, no worries! 